### PR TITLE
Fix the liquibase changeset id too long issue

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -325,7 +325,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="Create-privilege-manage-appointment-service-availability-202510101200" author="Bahmni">
+    <changeSet id="Create-privilege-appointment-service-availability-202510101200" author="Bahmni">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from privilege where privilege='app:appointments:manageServiceAvailability'</sqlCheck>
         </preConditions>


### PR DESCRIPTION
**Product version Upgrade**
Hive Card: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=3pGTwjtdrmzBMCYTZ


- The liquibase changeset on failure was causing issue to bring the appointments backend to  running state. So fixed the id length issue.